### PR TITLE
Made compatible with idemix_terminal 0.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     compile 'org.apache.tomcat:tomcat-util:7.0.41'
 
-    compile "org.irmacard.idemix:idemix_terminal:0.10.0"
+    compile "org.irmacard.idemix:idemix_terminal:0.10.1"
 
     compile "org.restlet.jee:org.restlet:2.3.2"
     compile "org.restlet.jee:org.restlet.ext.json:2.3.2"

--- a/src/main/java/org/irmacard/web/restapi/resources/StudentCardIssueResource.java
+++ b/src/main/java/org/irmacard/web/restapi/resources/StudentCardIssueResource.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.irmacard.credentials.idemix.descriptions.IdemixCredentialDescription;
+import org.irmacard.credentials.info.CredentialDescription;
+import org.irmacard.credentials.info.DescriptionStore;
 import org.irmacard.credentials.info.InfoException;
 import org.irmacard.web.restapi.ProtocolState;
 import org.irmacard.web.restapi.util.IssueCredentialInfo;
@@ -55,6 +57,8 @@ public class StudentCardIssueResource extends IssueBaseResource {
 
 	public IdemixCredentialDescription getIdemixCredentialDescription(String cred)
 			throws InfoException {
-		return new IdemixCredentialDescription(ISSUER, cred);
+		DescriptionStore ds = DescriptionStore.getInstance();
+		CredentialDescription cd = ds.getCredentialDescriptionByName(ISSUER, cred);
+		return new IdemixCredentialDescription(cd);
 	}
 }

--- a/src/main/java/org/irmacard/web/restapi/resources/irmaTube/IRMATubeRegistrationIssueResource.java
+++ b/src/main/java/org/irmacard/web/restapi/resources/irmaTube/IRMATubeRegistrationIssueResource.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.irmacard.credentials.idemix.descriptions.IdemixCredentialDescription;
+import org.irmacard.credentials.info.CredentialDescription;
+import org.irmacard.credentials.info.DescriptionStore;
 import org.irmacard.credentials.info.InfoException;
 import org.irmacard.web.restapi.ProtocolState;
 import org.irmacard.web.restapi.resources.IssueBaseResource;
@@ -47,6 +49,8 @@ public class IRMATubeRegistrationIssueResource extends IssueBaseResource {
 
 	public IdemixCredentialDescription getIdemixCredentialDescription(String cred)
 			throws InfoException {
-		return new IdemixCredentialDescription(ISSUER, cred);
+		DescriptionStore ds = DescriptionStore.getInstance();
+		CredentialDescription cd = ds.getCredentialDescriptionByName(ISSUER, cred);
+		return new IdemixCredentialDescription(cd);
 	}
 }

--- a/src/main/java/org/irmacard/web/restapi/resources/irmaWiki/IRMAWikiRegistrationIssueResource.java
+++ b/src/main/java/org/irmacard/web/restapi/resources/irmaWiki/IRMAWikiRegistrationIssueResource.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.irmacard.credentials.idemix.descriptions.IdemixCredentialDescription;
+import org.irmacard.credentials.info.CredentialDescription;
+import org.irmacard.credentials.info.DescriptionStore;
 import org.irmacard.credentials.info.InfoException;
 import org.irmacard.web.restapi.ProtocolState;
 import org.irmacard.web.restapi.resources.IssueBaseResource;
@@ -73,6 +75,8 @@ public class IRMAWikiRegistrationIssueResource extends IssueBaseResource {
 
 	public IdemixCredentialDescription getIdemixCredentialDescription(String cred)
 			throws InfoException {
-		return new IdemixCredentialDescription(ISSUER, cred);
+		DescriptionStore ds = DescriptionStore.getInstance();
+		CredentialDescription cd = ds.getCredentialDescriptionByName(ISSUER, cred);
+		return new IdemixCredentialDescription(cd);
 	}
 }

--- a/src/main/java/org/irmacard/web/restapi/resources/surfnetRegister/SurfnetRegistrationIssueResource.java
+++ b/src/main/java/org/irmacard/web/restapi/resources/surfnetRegister/SurfnetRegistrationIssueResource.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.irmacard.credentials.idemix.descriptions.IdemixCredentialDescription;
+import org.irmacard.credentials.info.CredentialDescription;
+import org.irmacard.credentials.info.DescriptionStore;
 import org.irmacard.credentials.info.InfoException;
 import org.irmacard.web.restapi.resources.IssueBaseResource;
 import org.irmacard.web.restapi.util.IssueCredentialInfo;
@@ -44,6 +46,8 @@ public class SurfnetRegistrationIssueResource extends IssueBaseResource {
 
     public IdemixCredentialDescription getIdemixCredentialDescription(String cred)
             throws InfoException {
-        return new IdemixCredentialDescription(ISSUER, cred);
+        DescriptionStore ds = DescriptionStore.getInstance();
+        CredentialDescription cd = ds.getCredentialDescriptionByName(ISSUER, cred);
+        return new IdemixCredentialDescription(cd);
     }
 }


### PR DESCRIPTION
Building this project fails because idemix_terminal 0.10 isn't available anymore in the repository. This pull request makes irma_web_service compatible with idemix_terminal 0.10.1 and makes it compilable again.
